### PR TITLE
added --watcher polling to CMD so livereload will correctly works on …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ EXPOSE 4200 49152
 
 WORKDIR /web
 
-CMD ['ember','server']
+CMD ['ember','server','--watcher, 'polling']

--- a/README.md
+++ b/README.md
@@ -118,3 +118,6 @@ services:
     environment:
       - STRIPE_CLIENT_ID=thevalue
 ```
+### Windows users
+
+You will need to add '--watcher polling' in command as a parameter. it is likely that the changes of file on host machine will not correctly processed inside the docker. Changing a watchman from tracking events to polling file updates will solve the issue with live reloads.

--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ services:
 ```
 ### Windows users
 
-You will need to add '--watcher polling' in command as a parameter. it is likely that the changes of file on host machine will not correctly processed inside the docker. Changing a watchman from tracking events to polling file updates will solve the issue with live reloads.
+You will need to add `--watcher polling` in command as a parameter. it is likely that the changes of file on host machine will not correctly processed inside the docker. Changing a watchman from tracking events to polling file updates will solve the issue with live reloads.


### PR DESCRIPTION
…docker for windows

u also need to speciy it in docker-compose command. example part of mine:

services:
  backoffice:

    image: myxtramile/backoffice
    build:
      context: .
      dockerfile: Dockerfile
    command: ember server --live-reload-port 35730 --watcher polling